### PR TITLE
chore(deps): bump required ruby version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 3.0
-          - 3.1
           - 3.2
+          - 3.3
+          - 3.4
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
@@ -27,6 +27,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0
+          ruby-version: 3.2
       - run: bin/setup
       - run: bin/rake rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ AllCops:
     - bin/rake
     - gemfiles/**/*
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.2
 
 RSpec/FilePath:
   Enabled: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,8 +87,7 @@ GEM
     unicode-display_width (2.5.0)
 
 PLATFORMS
-  arm64-darwin-22
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   appraisal

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,4 +103,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.4.17
+   2.6.3

--- a/omniauth-strategies-passthrough.gemspec
+++ b/omniauth-strategies-passthrough.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.require_path = 'lib'
 
   spec.version = OmniAuth::Strategies::Passthrough::VERSION
-  spec.required_ruby_version = '>= 3.0'
+  spec.required_ruby_version = '>= 3.2'
   spec.add_dependency 'omniauth', '>= 1.9', '< 3'
 end


### PR DESCRIPTION
update the required ruby version to 3.2, expand test matrix to cover 3.2-3.4

BREAKING CHANGE: Ruby versions below 3.2 are no longer supported.

